### PR TITLE
feat!: use literal terms as schematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,10 @@ schematic works by constructing **schematics** that specify your data and can th
 
 There are 12 builtin schematics that you can use to build new schematics that fit your own domain model.
 
-- `null/0`
-- `bool/1`
-- `str/1`
-- `int/1`
-- `float/1`
+- `bool/0`
+- `str/0`
+- `int/0`
+- `float/0`
 - `list/1`
 - `tuple/1`
 - `map/1`
@@ -26,6 +25,8 @@ There are 12 builtin schematics that you can use to build new schematics that fi
 - `any/0`
 - `all/1`
 - `oneof/1`
+
+Literals can be used as schematics and are unified with `==` semantics.
 
 ## Example
 
@@ -51,14 +52,6 @@ defmodule Bookstore do
             DateTime.to_iso8601(i)
         end
       )
-    end
-  end
-
-  defmodule Enum do
-    import Schematic
-
-    def schematic(strings) do
-      oneof(Elixir.Enum.map(strings, &str/1))
     end
   end
 
@@ -111,11 +104,11 @@ defmodule Bookstore do
           nullable(
             map(%{
               {"field", :field} =>
-                SchematicTest.Bookstore.Enum.schematic(["title", "authors", "publication_date"]),
+                oneof(["title", "authors", "publication_date"]),
               {"value", :value} => str()
             })
           ),
-        order: nullable(oneof([str("asc"), str("desc")]))
+        order: nullable(oneof(["asc", "desc"]))
       })
     end
   end
@@ -128,7 +121,7 @@ defmodule Bookstore do
     def schematic() do
       schema(__MODULE__, %{
         id: int(),
-        method: str("books/list"),
+        method: "books/list",
         params: Bookstore.BooksListParams.schematic()
       })
     end

--- a/lib/schematic.ex
+++ b/lib/schematic.ex
@@ -115,40 +115,26 @@ defmodule Schematic do
   A boolean literal.
 
   ```elixir
-  iex> schematic = bool(true)
+  iex> schematic = true
   iex> {:ok, true} = unify(schematic, true)
   iex> {:error, "expected true"} = unify(schematic, :boom)
   ```
   """
-  @spec bool(boolean() | nil) :: t()
-  def bool(literal \\ nil) do
+  @spec bool() :: t()
+  def bool() do
     message = fn ->
-      if is_boolean(literal) do
-        "#{inspect(literal)}"
-      else
-        "a boolean"
-      end
+      "a boolean"
     end
 
     %Schematic{
       kind: "boolean",
       message: message,
       unify:
-        telemetry_wrap(:bool, %{literal: not is_nil(literal)}, fn input, _dir ->
-          # FIXME: this is ugly
-          cond do
-            is_boolean(literal) ->
-              if is_boolean(input) && input == literal do
-                {:ok, input}
-              else
-                {:error, ~s|expected #{message.()}|}
-              end
-
-            is_boolean(input) ->
-              {:ok, input}
-
-            true ->
-              {:error, "expected #{message.()}"}
+        telemetry_wrap(:bool, %{}, fn input, _dir ->
+          if is_boolean(input) do
+            {:ok, input}
+          else
+            {:error, "expected #{message.()}"}
           end
         end)
     }
@@ -170,40 +156,26 @@ defmodule Schematic do
   A string literal.
 
   ```elixir
-  iex> schematic = str("I 💜 Elixir")
+  iex> schematic = "I 💜 Elixir"
   iex> {:ok, "I 💜 Elixir"} = unify(schematic,  "I 💜 Elixir")
-  iex> {:error, ~s|expected the literal string "I 💜 Elixir"|} = unify(schematic, "I love Ruby")
+  iex> {:error, ~s|expected "I 💜 Elixir"|} = unify(schematic, "I love Ruby")
   ```
   """
-  @spec str(String.t() | nil) :: t()
-  def str(literal \\ nil) do
+  @spec str() :: t()
+  def str() do
     message = fn ->
-      if literal do
-        "the literal string #{inspect(literal)}"
-      else
-        "a string"
-      end
+      "a string"
     end
 
     %Schematic{
       kind: "string",
       message: message,
       unify:
-        telemetry_wrap(:str, %{literal: not is_nil(literal)}, fn input, _dir ->
-          # FIXME: this is ugly
-          cond do
-            is_binary(literal) ->
-              if is_binary(input) && input == literal do
-                {:ok, input}
-              else
-                {:error, ~s|expected #{message.()}|}
-              end
-
-            is_binary(input) ->
-              {:ok, input}
-
-            true ->
-              {:error, "expected #{message.()}"}
+        telemetry_wrap(:str, %{}, fn input, _dir ->
+          if is_binary(input) do
+            {:ok, input}
+          else
+            {:error, "expected #{message.()}"}
           end
         end)
     }
@@ -225,40 +197,26 @@ defmodule Schematic do
   A integer literal.
 
   ```elixir
-  iex> schematic = int(99)
+  iex> schematic = 99
   iex> {:ok, 99} = unify(schematic,  99)
-  iex> {:error, ~s|expected the literal integer 99|} = unify(schematic, :ninetynine)
+  iex> {:error, ~s|expected 99|} = unify(schematic, :ninetynine)
   ```
   """
-  @spec int(integer() | nil) :: t()
-  def int(literal \\ nil) do
+  @spec int() :: t()
+  def int() do
     message = fn ->
-      if literal do
-        "the literal integer #{inspect(literal)}"
-      else
-        "an integer"
-      end
+      "an integer"
     end
 
     %Schematic{
       kind: "integer",
       message: message,
       unify:
-        telemetry_wrap(:int, %{literal: not is_nil(literal)}, fn input, _dir ->
-          # FIXME: this is ugly
-          cond do
-            is_integer(literal) ->
-              if is_integer(input) && input == literal do
-                {:ok, input}
-              else
-                {:error, ~s|expected #{message.()}|}
-              end
-
-            is_integer(input) ->
-              {:ok, input}
-
-            true ->
-              {:error, "expected #{message.()}"}
+        telemetry_wrap(:int, %{}, fn input, _dir ->
+          if is_integer(input) do
+            {:ok, input}
+          else
+            {:error, "expected #{message.()}"}
           end
         end)
     }
@@ -273,26 +231,22 @@ defmodule Schematic do
 
   ```elixir
   iex> schematic = float()
-  iex> {:ok, 99.0} = unify(schematic, 99.0) 
+  iex> {:ok, 99.0} = unify(schematic, 99.0)
   iex> {:error, "expected a float"} = unify(schematic, :boom)
   ```
 
   A float literal.
 
   ```elixir
-  iex> schematic = float(99.0)
+  iex> schematic = 99.0
   iex> {:ok, 99.0} = unify(schematic,  99.0)
-  iex> {:error, ~s|expected the literal float 99.0|} = unify(schematic, :ninetynine)
+  iex> {:error, ~s|expected 99.0|} = unify(schematic, :ninetynine)
   ```
   """
   @spec float(float() | nil) :: t()
   def float(literal \\ nil) do
     message = fn ->
-      if literal do
-        "the literal float #{inspect(literal)}"
-      else
-        "a float"
-      end
+      "a float"
     end
 
     %Schematic{
@@ -300,20 +254,10 @@ defmodule Schematic do
       message: message,
       unify:
         telemetry_wrap(:float, %{literal: not is_nil(literal)}, fn input, _dir ->
-          # FIXME: this is ugly
-          cond do
-            is_float(literal) ->
-              if is_float(input) && abs(input - literal) <= 0.01 do
-                {:ok, input}
-              else
-                {:error, ~s|expected #{message.()}|}
-              end
-
-            is_float(input) ->
-              {:ok, input}
-
-            true ->
-              {:error, "expected #{message.()}"}
+          if is_float(input) do
+            {:ok, input}
+          else
+            {:error, "expected #{message.()}"}
           end
         end)
     }
@@ -426,7 +370,10 @@ defmodule Schematic do
   @spec tuple([t() | lazy_schematic()], Keyword.t()) :: t()
   def tuple(schematics, opts \\ []) do
     from = Keyword.get(opts, :from, :tuple)
-    message = fn -> "a #{from} of {#{Enum.map_join(schematics, ", ", & &1.message.())}}" end
+
+    message = fn ->
+      "a #{from} of {#{Enum.map_join(schematics, ", ", &Schematic.Unification.message/1)}}"
+    end
 
     {condition, to_list, length} =
       case from do
@@ -446,7 +393,7 @@ defmodule Schematic do
           |> to_list.()
           |> Enum.with_index()
           |> Enum.reduce_while({:ok, []}, fn {el, idx}, {:ok, acc} ->
-            case Enum.at(schematics, idx).unify.(el, dir) do
+            case Schematic.Unification.unify(Enum.at(schematics, idx), el, dir) do
               {:ok, output} ->
                 {:cont, {:ok, [output | acc]}}
 
@@ -483,7 +430,7 @@ defmodule Schematic do
 
   ```elixir
   iex> schematic = map(%{
-  ...>   "league" => oneof([str("NBA"), str("MLB"), str("NFL")]),
+  ...>   "league" => oneof(["NBA", "MLB", "NFL"]),
   ...> })
   iex> # ignores the `"team"` key
   iex> {:ok, %{"league" => "NBA"}} == unify(schematic, %{"league" => "NBA", "team" => "Chicago Bulls"})
@@ -491,7 +438,7 @@ defmodule Schematic do
   iex> {:error,
   ...>   %{
   ...>     "league" =>
-  ...>     ~s|expected either the literal string "NBA", the literal string "MLB", or the literal string "NFL"|
+  ...>     ~s|expected either "NBA", "MLB", or "NFL"|
   ...>   }} = unify(schematic, %{"league" => "NHL"})
   ```
 
@@ -672,7 +619,7 @@ defmodule Schematic do
                 if not Map.has_key?(input, from_key) and match?(%OptionalKey{}, bpk) do
                   [{:ok, acc}, {:errors, errors}]
                 else
-                  case schematic.unify.(input[from_key], dir) do
+                  case Schematic.Unification.unify(schematic, input[from_key], dir) do
                     {:ok, output} ->
                       acc =
                         acc
@@ -762,7 +709,7 @@ defmodule Schematic do
   ```elixir
   iex> schematic =
   ...>   schema(HTTPRequest, %{
-  ...>     method: oneof([str("POST"), str("PUT"), str("PATCH")]),
+  ...>     method: oneof(["POST", "PUT", "PATCH"]),
   ...>     body: str()
   ...>   })
   iex> {:ok, %HTTPRequest{method: "POST", body: ~s|{"name": "Peter"}|}} = unify(schematic, %{"method" => "POST", "body" => ~s|{"name": "Peter"}|})
@@ -922,7 +869,8 @@ defmodule Schematic do
         telemetry_wrap(:all, %{}, fn input, dir ->
           errors =
             for schematic <- schematics,
-                {result, message} = __try__(fn -> schematic.unify.(input, dir) end),
+                {result, message} =
+                  __try__(fn -> Schematic.Unification.unify(schematic, input, dir) end),
                 result == :error do
               message
             end
@@ -978,7 +926,9 @@ defmodule Schematic do
   """
   @spec oneof([t() | lazy_schematic()] | (any -> t())) :: t()
   def oneof(schematics) when is_list(schematics) do
-    message = fn -> "either #{sentence_join(schematics, "or", & &1.message.())}" end
+    message = fn ->
+      "either #{sentence_join(schematics, "or", &Schematic.Unification.message/1)}"
+    end
 
     %Schematic{
       kind: "oneof",
@@ -993,7 +943,7 @@ defmodule Schematic do
                   schematic -> schematic
                 end
 
-              with {:error, _} <- schematic.unify.(input, dir), do: false
+              with {:error, _} <- Schematic.Unification.unify(schematic, input, dir), do: false
             end)
 
           with nil <- inquiry, do: {:error, ~s|expected #{message.()}|}
@@ -1007,7 +957,7 @@ defmodule Schematic do
       unify:
         telemetry_wrap(:oneof, %{style: :dispatch}, fn input, dir ->
           with %Schematic{} = schematic <- dispatch.(input) do
-            schematic.unify.(input, dir)
+            Schematic.Unification.unify(schematic, input, dir)
           end
         end)
     }
@@ -1027,9 +977,9 @@ defmodule Schematic do
 
   See all the other functions for information on how to create schematics.
   """
-  @spec unify(t(), any()) :: any()
+  @spec unify(t() | any(), any()) :: any()
   def unify(schematic, input) do
-    schematic.unify.(input, :to)
+    Schematic.Unification.unify(schematic, input, :to)
   end
 
   @doc """
@@ -1037,9 +987,9 @@ defmodule Schematic do
 
   See all the other functions for information on how to create schematics.
   """
-  @spec dump(t(), any()) :: any()
+  @spec dump(t() | any(), any()) :: any()
   def dump(schematic, input) do
-    schematic.unify.(input, :from)
+    Schematic.Unification.unify(schematic, input, :from)
   end
 
   defp telemetry_wrap(type, metadata, func) do

--- a/lib/schematic/unification.ex
+++ b/lib/schematic/unification.ex
@@ -1,0 +1,30 @@
+defprotocol Schematic.Unification do
+  @moduledoc false
+  @fallback_to_any true
+  def unify(schematic, value, direction)
+  def message(schematic)
+end
+
+defimpl Schematic.Unification, for: Schematic do
+  def unify(schematic, input, direction) do
+    schematic.unify.(input, direction)
+  end
+
+  def message(schematic) do
+    schematic.message.()
+  end
+end
+
+defimpl Schematic.Unification, for: Any do
+  def unify(literal, value, _ \\ nil) do
+    if literal == value do
+      {:ok, value}
+    else
+      {:error, "expected #{inspect(literal)}"}
+    end
+  end
+
+  def message(literal) do
+    inspect(literal)
+  end
+end

--- a/test/schematic_test.exs
+++ b/test/schematic_test.exs
@@ -37,7 +37,7 @@ defmodule SchematicTest do
     end
 
     test "str/1" do
-      schematic = str("lsp is kool")
+      schematic = "lsp is kool"
       input = "lsp is kool"
       assert {:ok, input} == unify(schematic, input)
     end
@@ -48,9 +48,15 @@ defmodule SchematicTest do
       assert {:ok, input} == unify(schematic, input)
     end
 
-    test "int/1" do
-      schematic = int(999)
+    test "int literal" do
+      schematic = 999
       input = 999
+      assert {:ok, input} == unify(schematic, input)
+    end
+
+    test "map literal" do
+      schematic = %{foo: 10}
+      input = %{foo: 10}
       assert {:ok, input} == unify(schematic, input)
     end
 
@@ -60,14 +66,14 @@ defmodule SchematicTest do
       assert {:ok, input} == unify(schematic, input)
     end
 
-    test "float/1" do
-      schematic = float(999.0)
+    test "float literal" do
+      schematic = 999.0
       input = 999.0
       assert {:ok, input} == unify(schematic, input)
 
-      schematic = float(999.02)
+      schematic = 999.02
       input = 999.0
-      assert {:error, "expected the literal float 999.02"} == unify(schematic, input)
+      assert {:error, "expected 999.02"} == unify(schematic, input)
     end
 
     test "map/0" do
@@ -184,7 +190,7 @@ defmodule SchematicTest do
           "foo" => oneof([str(), int()]),
           "bar" =>
             map(%{
-              "alice" => str("Alice"),
+              "alice" => "Alice",
               "bob" => list(str()),
               "carol" =>
                 map(%{
@@ -219,7 +225,7 @@ defmodule SchematicTest do
           {"foo", :foo} => oneof([str(), int()]),
           {"bar", :bar} =>
             map(%{
-              {"alice", :alice} => str("Alice"),
+              {"alice", :alice} => "Alice",
               {"bob", :bob} => list(str()),
               {"carol", :carol} =>
                 map(%{
@@ -286,7 +292,7 @@ defmodule SchematicTest do
           {"foo", :foo} => oneof([str(), int()]),
           bar:
             schema(S2, %{
-              {"alice", :alice} => str("Alice"),
+              {"alice", :alice} => "Alice",
               {"bob", :bob} => list(str()),
               {"carol", :carol} =>
                 schema(S3, %{
@@ -333,11 +339,11 @@ defmodule SchematicTest do
       assert {:ok, true} = unify(schematic, true)
       assert {:ok, false} = unify(schematic, false)
 
-      schematic = bool(true)
+      schematic = true
       assert {:ok, true} = unify(schematic, true)
       assert {:error, "expected true"} = unify(schematic, false)
 
-      schematic = bool(false)
+      schematic = false
       assert {:ok, false} = unify(schematic, false)
       assert {:error, "expected false"} = unify(schematic, true)
     end
@@ -393,7 +399,7 @@ defmodule SchematicTest do
         map(%{
           "name" => str(),
           "grade" => int(),
-          "prefix" => oneof([str("Mrs."), str("Mr.")])
+          "prefix" => oneof(["Mrs.", "Mr."])
         })
 
       schematic =
@@ -401,8 +407,8 @@ defmodule SchematicTest do
           "foo" => oneof([str(), int(), list()]),
           "bar" => str(),
           "baz" => list(),
-          "alice" => str("foo"),
-          "bob" => int(99),
+          "alice" => "foo",
+          "bob" => 99,
           "carol" => oneof([null(), int()]),
           "dave" =>
             map(%{
@@ -426,18 +432,17 @@ defmodule SchematicTest do
 
       assert {:error,
               %{
-                "alice" => "expected the literal string \"foo\"",
+                "alice" => "expected \"foo\"",
                 "bar" => "expected a string",
                 "baz" => "expected a list",
-                "bob" => "expected the literal integer 99",
+                "bob" => "expected 99",
                 "dave" => %{
                   "first" => "expected an integer",
                   "second" => "expected a list of either a list or a map",
                   "teacher" => %{
                     "grade" => "expected an integer",
                     "name" => "expected a string",
-                    "prefix" =>
-                      "expected either the literal string \"Mrs.\" or the literal string \"Mr.\""
+                    "prefix" => "expected either \"Mrs.\" or \"Mr.\""
                   }
                 },
                 "foo" => "expected either a string, an integer, or a list"
@@ -613,13 +618,13 @@ defmodule SchematicTest do
       schematic =
         oneof(fn
           %{type: "foo"} ->
-            map(%{type: str("foo")})
+            map(%{type: "foo"})
 
           %{type: "bar"} ->
-            map(%{type: str("bar")})
+            map(%{type: "bar"})
 
           %{type: "baz"} ->
-            map(%{type: str("baz")})
+            map(%{type: "baz"})
 
           %{type: type} ->
             {:error, ~s|unexpected record type "#{type}"|}

--- a/test/support/bookstore.ex
+++ b/test/support/bookstore.ex
@@ -20,14 +20,6 @@ defmodule SchematicTest.Bookstore do
     end
   end
 
-  defmodule Enum do
-    import Schematic
-
-    def schematic(strings) do
-      oneof(Elixir.Enum.map(strings, &str/1))
-    end
-  end
-
   defmodule Author do
     import Schematic
 
@@ -76,12 +68,11 @@ defmodule SchematicTest.Bookstore do
         query:
           nullable(
             map(%{
-              {"field", :field} =>
-                SchematicTest.Bookstore.Enum.schematic(["title", "authors", "publication_date"]),
+              {"field", :field} => oneof(["title", "authors", "publication_date"]),
               {"value", :value} => str()
             })
           ),
-        order: nullable(oneof([str("asc"), str("desc")]))
+        order: nullable(oneof(["asc", "desc"]))
       })
     end
   end
@@ -94,7 +85,7 @@ defmodule SchematicTest.Bookstore do
     def schematic() do
       schema(__MODULE__, %{
         id: int(),
-        method: str("books/list"),
+        method: "books/list",
         params: SchematicTest.Bookstore.BooksListParams.schematic()
       })
     end

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -90,42 +90,42 @@ defmodule SchematicTest.Generators do
   defp schematic_from_data(data) when is_integer(data) do
     StreamData.member_of([
       Schematic.int(),
-      Schematic.int(data),
+      data,
       Schematic.oneof([Schematic.int(), simple_schematic() |> Enum.fetch!(1)]),
-      Schematic.oneof([Schematic.int(data), simple_schematic() |> Enum.fetch!(1)])
+      Schematic.oneof([data, simple_schematic() |> Enum.fetch!(1)])
     ])
   end
 
   defp schematic_from_data(data) when is_float(data) do
     StreamData.member_of([
       Schematic.float(),
-      Schematic.float(data),
+      data,
       Schematic.oneof([Schematic.float(), simple_schematic() |> Enum.fetch!(1)]),
-      Schematic.oneof([Schematic.float(data), simple_schematic() |> Enum.fetch!(1)])
+      Schematic.oneof([data, simple_schematic() |> Enum.fetch!(1)])
     ])
   end
 
   defp schematic_from_data(data) when is_binary(data) do
     StreamData.member_of([
       Schematic.str(),
-      Schematic.str(data),
+      data,
       Schematic.oneof([Schematic.str(), simple_schematic() |> Enum.fetch!(1)]),
-      Schematic.oneof([Schematic.str(data), simple_schematic() |> Enum.fetch!(1)])
+      Schematic.oneof([data, simple_schematic() |> Enum.fetch!(1)])
     ])
   end
 
   defp schematic_from_data(data) when is_boolean(data) do
     StreamData.member_of([
       Schematic.bool(),
-      Schematic.bool(data),
+      data,
       Schematic.oneof([Schematic.bool(), simple_schematic() |> Enum.fetch!(1)]),
-      Schematic.oneof([Schematic.bool(data), simple_schematic() |> Enum.fetch!(1)])
+      Schematic.oneof([data, simple_schematic() |> Enum.fetch!(1)])
     ])
   end
 
   defp schematic_from_data(data) when is_nil(data) do
     StreamData.member_of([
-      Schematic.null(),
+      nil,
       Schematic.nullable(simple_schematic() |> Enum.fetch!(1))
     ])
   end


### PR DESCRIPTION
terms can be used as schematics to match on literal values.

This makes defining enums much simpler, as well as making
the code more maintainable.
