### PR TITLE
test: fine tune property tests

### DIFF
--- a/test/schematic_test.exs
+++ b/test/schematic_test.exs
@@ -19,8 +19,9 @@ defmodule SchematicTest do
   end
 
   describe "unify" do
-    property "input |> unify |> dump == input" do
-      check all {schematic, input} <- Generators.schematic_and_data() do
+    property "input |> unify |> dump == input, excluding 'blueprint' maps" do
+      check all {schematic, input} <-
+                  Generators.schematic_and_data(maps: [excluding: ~w(blueprint)]) do
         assert {:ok, result} = unify(schematic, input)
         assert {:ok, input} == dump(schematic, result)
       end


### PR DESCRIPTION
## Draft disclaimer

i'm not married to _anything_ here, and would appreciate _any and all feedback_

## Description


### the problem

allowing "blueprint"-style map schematics at the root-level of a `list/1` schematic means that there is a chance (higher chance the more you run the property test) that you end up with a `oneof/1` schematic to cover a list with a variety of maps in it where one of the `map/1` schematics in that `oneof` is a highly permissive one, like `map(%{})`, which will readily unify with any map and then drop all of the keys when it is dumped out

### the solution?

see the discussion below. TL;DR: we're not so sure

an additional property (or several) can at least be added to describe the behaviours of map schematics, particularly when there are unspecified keys that will be lost during unification

Closes #22 

## Specific requests for feedback

- in our thread for #22 we discussed limiting the generation space for the `input |> unify |> dump == input` test; is this going too far?
    - related: i tried re-writing the generator to allow for a specific option to be passed in to avoid lists with a root-level map schematic defined using a "blueprint", but the resulting options (not to mention implementation) started to feel very cumbersome and confusing. it seems to me that having that level of granularity would be more trouble than it's worth

## TODOs

- [ ] add a follow-up property test to describe the behaviour of map blueprint schematics, i.e. "unspecified keys in a map blueprint are discarded when dumped"