### PR TITLE
feat: inspect protocol

### DIFF
--- a/lib/schematic/inspect.ex
+++ b/lib/schematic/inspect.ex
@@ -1,0 +1,18 @@
+defimpl Inspect, for: Schematic do
+  def inspect(schematic, opts) do
+    schematic.inspect.(nil, opts) |> Code.format_string!() |> IO.iodata_to_binary()
+  end
+end
+
+defimpl Inspect, for: Schematic.OptionalKey do
+  def inspect(optional_key, _opts) do
+    default =
+      if optional_key.default do
+        ", #{inspect(optional_key.default)}"
+      else
+        ""
+      end
+
+    "optional(#{inspect(optional_key.key)}#{default})"
+  end
+end


### PR DESCRIPTION
Implements the inspect protocol for Schematic, which allows a more or
less a "as you typed it" representation of the schematic. This makes
debugging schematics much easier, as previously, any nested schematics
were hidden behind an anonymous function
